### PR TITLE
Set STACK_ROOT to C:\sr by default

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -41,6 +41,11 @@ main = writeFile "stack-install.nsi" $ nsis $ do
     [ Description "Add installation directory to user %PATH% to allow running Stack in the console."
     ] $ do
       setEnvVarPrepend HKCU "PATH" "$INSTDIR"
+      
+  section "Set STACK_ROOT to recommended default"
+    [ Description "Set STACK_ROOT to C:\sr to workaround issues with long paths."
+    ] $ do
+      setEnvVar HKCU "STACK_ROOT" "C:\\sr"
 
   -- Uninstallation sections. (Any section prepended with "un." is an
   -- uninstallation option.)
@@ -59,6 +64,11 @@ main = writeFile "stack-install.nsi" $ nsis $ do
     ] $ do
       setEnvVarRemove HKCU "PATH" "$INSTDIR"
 
+  section "un.Set STACK_ROOT to recommended default"
+    [ Description "Remove setting of STACK_ROOT to C:\sr."
+    ] $ do
+      deleteEnvVar HKCU "STACK_ROOT"
+      
   section "un.Compilers installed by stack"
     [ Unselected
     , Description "Remove %LOCALAPPDATA%/Programs/stack, which contains compilers that have been installed by Stack."

--- a/Main.hs
+++ b/Main.hs
@@ -42,8 +42,8 @@ main = writeFile "stack-install.nsi" $ nsis $ do
     ] $ do
       setEnvVarPrepend HKCU "PATH" "$INSTDIR"
       
-  section "Set STACK_ROOT to recommended default"
-    [ Description "Set STACK_ROOT to C:\sr to workaround issues with long paths."
+  section "Set %STACK_ROOT% to recommended default"
+    [ Description "Set %STACK_ROOT% to C:\\sr to workaround issues with long paths."
     ] $ do
       setEnvVar HKCU "STACK_ROOT" "C:\\sr"
 
@@ -64,8 +64,8 @@ main = writeFile "stack-install.nsi" $ nsis $ do
     ] $ do
       setEnvVarRemove HKCU "PATH" "$INSTDIR"
 
-  section "un.Set STACK_ROOT to recommended default"
-    [ Description "Remove setting of STACK_ROOT to C:\sr."
+  section "un.Set %STACK_ROOT% to recommended default"
+    [ Description "Remove setting of %STACK_ROOT% to C:\\sr."
     ] $ do
       deleteEnvVar HKCU "STACK_ROOT"
       


### PR DESCRIPTION
Completely untested yet—treat this as pseudocode for now (though I skimmed docs).
EDIT: Tested on Windows 10, appears to work well now.
Only problem: the description of options in the uninstallers aren't visible. But I've confirmed this is not a regression.

Fix commercialhaskell/stack#2468.
